### PR TITLE
Graceful shutdown을 테스트하기 위한 별도의 API 및 페이지 구성 

### DIFF
--- a/src/main/java/com/working/pic/common/controller/HealthCheckController.java
+++ b/src/main/java/com/working/pic/common/controller/HealthCheckController.java
@@ -1,4 +1,4 @@
-package com.working.pic.common.healthcheck;
+package com.working.pic.common.controller;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.springframework.http.HttpStatus;

--- a/src/main/java/com/working/pic/common/controller/HealthCheckController.java
+++ b/src/main/java/com/working/pic/common/controller/HealthCheckController.java
@@ -13,11 +13,11 @@ public class HealthCheckController {
     private final AtomicBoolean isTerminated = new AtomicBoolean(false);
 
     @GetMapping("/healthcheck")
-    public ResponseEntity<Void> healthCheck() {
+    public ResponseEntity<String> healthCheck() {
         if (isTerminated.get()) {
             return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE).build();
         }
-        return ResponseEntity.ok().build();
+        return ResponseEntity.ok("healthy");
     }
 
     @PostMapping("/terminate")

--- a/src/main/java/com/working/pic/common/controller/HealthCheckController.java
+++ b/src/main/java/com/working/pic/common/controller/HealthCheckController.java
@@ -15,7 +15,7 @@ public class HealthCheckController {
     @GetMapping("/healthcheck")
     public ResponseEntity<String> healthCheck() {
         if (isTerminated.get()) {
-            return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE).build();
+            return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE).body("terminated");
         }
         return ResponseEntity.ok("healthy");
     }

--- a/src/main/java/com/working/pic/common/controller/ShutdownController.java
+++ b/src/main/java/com/working/pic/common/controller/ShutdownController.java
@@ -1,0 +1,37 @@
+package com.working.pic.common.controller;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Controller
+@Slf4j
+public class ShutdownController {
+
+	private static final String DEFAULT_SHUTDOWN_DELAY = "30";
+
+	@GetMapping("/shutdown-test")
+	public String shutdownPage() {
+		return "shutdown";
+	}
+
+	@PostMapping("/shutdown-test")
+	public String shutdown(
+		@RequestParam(value = "delay", defaultValue = DEFAULT_SHUTDOWN_DELAY) int delay,
+		Model model
+	) {
+		log.info("Shutdown request received. Delay: {} seconds", delay);
+		try {
+			Thread.sleep(delay * 1000L);
+		} catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+		}
+
+		model.addAttribute("delay", delay);
+		return "success-shutdown";
+	}
+}

--- a/src/main/resources/static/css/styles.css
+++ b/src/main/resources/static/css/styles.css
@@ -15,23 +15,24 @@ h1, h2, h3 {
     margin-bottom: 20px;
 }
 
+h2, h3, p {
+    text-align: center;
+    margin-bottom: 20px;
+}
+
 @media (max-width: 1000px) {
-    .registration-form, .login-container {
+    .registration-form, .login-container, .container {
         transform: scale(2);
     }
 }
 
-
-.login-container, .registration-form, .headers-container {
+.login-container, .registration-form, .form-container, .success-container, .headers-container, .all-headers-container {
     background-color: white;
     padding: 30px;
     border-radius: 8px;
     box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
     width: 100%;
     max-width: 400px;
-}
-
-.login-container {
     display: flex;
     flex-direction: column;
     align-items: center;
@@ -46,21 +47,7 @@ h1, h2, h3 {
     margin-bottom: 20px;
 }
 
-.login-container p {
-    text-align: center;
-}
-
-.registration-form h3 {
-    text-align: left;
-    margin-bottom: 10px;
-}
-
-.registration-form p {
-    margin-top: 3px;
-    margin-bottom: 5px;
-}
-
-.login-btn, button {
+button, .login-btn {
     background-color: #007bff;
     color: white;
     padding: 10px 20px;
@@ -78,6 +65,7 @@ button:hover, .login-btn:hover {
 
 .form-group {
     margin-bottom: 20px; /* 간격을 더 넓혔습니다 */
+    width: 100%;
 }
 
 label {
@@ -129,10 +117,10 @@ tr:hover {
     background-color: #f1f1f1;
 }
 
-.all-headers-container {
-    background-color: white;
-    padding: 30px;
-    border-radius: 8px;
-    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
-    width: 100%;
+.success-container h2 {
+    color: #28a745;
+}
+
+.success-container p {
+    color: #555;
 }

--- a/src/main/resources/templates/shutdown.html
+++ b/src/main/resources/templates/shutdown.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <title>Graceful Shutdown 테스트</title>
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="/css/styles.css">
+</head>
+<body>
+<div class="login-container">
+    <h2>Graceful Shutdown 테스트</h2>
+    <h3>원하는 지연 시간을 지정하고 테스트를 시작하세요</h3>
+    <form id="shutdownForm" method="POST" action="/shutdown-test">
+        <div class="form-group">
+            <label for="delay">지연 시간 (초):</label>
+            <br/>
+            <input type="text" id="delay" name="delay" placeholder="예: 10">
+        </div>
+        <div class="button-container">
+            <button type="button" onclick="submitShutdownTest()">확인</button>
+        </div>
+    </form>
+</div>
+
+<script>
+    function submitShutdownTest() {
+        const delay = document.getElementById('delay').value;
+        if (delay) {
+            const form = document.getElementById('shutdownForm');
+            form.action = `/shutdown-test?delay=${delay}`;
+            form.submit();
+        } else {
+            alert("지연 시간을 입력해 주세요.");
+        }
+    }
+</script>
+</body>
+</html>

--- a/src/main/resources/templates/success-shutdown.html
+++ b/src/main/resources/templates/success-shutdown.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <title>Shutdown 테스트 완료</title>
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="/css/styles.css">
+</head>
+<body>
+<div class="success-container">
+    <h2>Graceful Shutdown 테스트 완료</h2>
+    <p>지연 시간: <span th:text="${delay}"></span>초</p>
+</div>
+</body>
+</html>


### PR DESCRIPTION
### PR의 목적이 무엇인가요?
Graceful shutdown을 테스트하기 위한 별도의 API 및 페이지 추가
 
### 이슈 ID는 무엇인가요?
#20 

### 내용
- [x] 입력된 시간만큼 Thread.sleep()을 호출하여 graceful shutdown을 테스트하는 API 추가
- [x] 배포 환경에서 테스트할 수 있도록 페이지 구성(/shutdown-test)
- [x] 헬스체크시 응답에 'healthy'와 같은 간단한 내용의 바디 추가