### PR TITLE
JSON 응답을 반환하는 shutdown-test API 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
+	testImplementation 'io.projectreactor:reactor-test'
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'com.h2database:h2'

--- a/src/main/java/com/working/pic/common/controller/HealthCheckController.java
+++ b/src/main/java/com/working/pic/common/controller/HealthCheckController.java
@@ -25,4 +25,10 @@ public class HealthCheckController {
         isTerminated.set(true);
         return ResponseEntity.ok().build();
     }
+
+    @PostMapping("/activate")
+    public ResponseEntity<Void> activate() {
+        isTerminated.set(false);
+        return ResponseEntity.ok().build();
+    }
 }

--- a/src/main/java/com/working/pic/common/controller/ShutdownController.java
+++ b/src/main/java/com/working/pic/common/controller/ShutdownController.java
@@ -1,5 +1,8 @@
 package com.working.pic.common.controller;
 
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -24,6 +27,8 @@ public class ShutdownController {
 		@RequestParam(value = "delay", defaultValue = DEFAULT_SHUTDOWN_DELAY) int delay,
 		Model model
 	) {
+		String requestTime = LocalDateTime.now()
+			.format(DateTimeFormatter.ofPattern("dd/MM/yyyy:HH:mm:ss"));
 		log.info("Shutdown request received. Delay: {} seconds", delay);
 		try {
 			Thread.sleep(delay * 1000L);
@@ -32,6 +37,7 @@ public class ShutdownController {
 		}
 
 		model.addAttribute("delay", delay);
+		model.addAttribute("requestTime", requestTime);
 		return "success-shutdown";
 	}
 }

--- a/src/main/java/com/working/pic/common/controller/ShutdownController.java
+++ b/src/main/java/com/working/pic/common/controller/ShutdownController.java
@@ -15,6 +15,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class ShutdownController {
 
+	private static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("dd/MM/yyyy:HH:mm:ss");
 	private static final String DEFAULT_SHUTDOWN_DELAY = "30";
 
 	@GetMapping("/shutdown-test")
@@ -27,8 +28,7 @@ public class ShutdownController {
 		@RequestParam(value = "delay", defaultValue = DEFAULT_SHUTDOWN_DELAY) int delay,
 		Model model
 	) {
-		String requestTime = LocalDateTime.now()
-			.format(DateTimeFormatter.ofPattern("dd/MM/yyyy:HH:mm:ss"));
+		LocalDateTime requestTime = LocalDateTime.now();
 		log.info("Shutdown request received. Delay: {} seconds", delay);
 		try {
 			Thread.sleep(delay * 1000L);
@@ -36,8 +36,11 @@ public class ShutdownController {
 			Thread.currentThread().interrupt();
 		}
 
-		model.addAttribute("delay", delay);
-		model.addAttribute("requestTime", requestTime);
+		LocalDateTime completeTime = LocalDateTime.now();
+		model.addAttribute("requestTime", requestTime.format(DATE_TIME_FORMATTER));
+		model.addAttribute("completeTime", completeTime.format(DATE_TIME_FORMATTER));
+		log.info("Shutdown request completed. requestTime: {}, completeTime: {}"
+			, requestTime.format(DATE_TIME_FORMATTER), completeTime.format(DATE_TIME_FORMATTER));
 		return "success-shutdown";
 	}
 }

--- a/src/main/java/com/working/pic/common/controller/ShutdownController.java
+++ b/src/main/java/com/working/pic/common/controller/ShutdownController.java
@@ -7,7 +7,9 @@ import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -29,18 +31,29 @@ public class ShutdownController {
 		Model model
 	) {
 		LocalDateTime requestTime = LocalDateTime.now();
-		log.info("Shutdown request received. Delay: {} seconds", delay);
+		LocalDateTime completeTime = run(delay);
+
+		model.addAttribute("requestTime", requestTime.format(DATE_TIME_FORMATTER));
+		model.addAttribute("completeTime", completeTime.format(DATE_TIME_FORMATTER));
+		return "success-shutdown";
+	}
+
+	@PostMapping("/shutdown-test-v2")
+	@ResponseBody
+	public ShutdownResponse shutdownV2(@RequestBody ShutdownRequest shutdownRequest) {
+		LocalDateTime requestTime = shutdownRequest.requestTime();
+		LocalDateTime completeTime = run(shutdownRequest.delay());
+
+		return new ShutdownResponse(requestTime.format(DATE_TIME_FORMATTER), completeTime.format(DATE_TIME_FORMATTER));
+	}
+
+	private LocalDateTime run(int delay) {
 		try {
 			Thread.sleep(delay * 1000L);
 		} catch (InterruptedException e) {
 			Thread.currentThread().interrupt();
 		}
 
-		LocalDateTime completeTime = LocalDateTime.now();
-		model.addAttribute("requestTime", requestTime.format(DATE_TIME_FORMATTER));
-		model.addAttribute("completeTime", completeTime.format(DATE_TIME_FORMATTER));
-		log.info("Shutdown request completed. requestTime: {}, completeTime: {}"
-			, requestTime.format(DATE_TIME_FORMATTER), completeTime.format(DATE_TIME_FORMATTER));
-		return "success-shutdown";
+		return LocalDateTime.now();
 	}
 }

--- a/src/main/java/com/working/pic/common/controller/ShutdownRequest.java
+++ b/src/main/java/com/working/pic/common/controller/ShutdownRequest.java
@@ -1,0 +1,9 @@
+package com.working.pic.common.controller;
+
+import java.time.LocalDateTime;
+
+public record ShutdownRequest(
+	LocalDateTime requestTime,
+	int delay
+) {
+}

--- a/src/main/java/com/working/pic/common/controller/ShutdownResponse.java
+++ b/src/main/java/com/working/pic/common/controller/ShutdownResponse.java
@@ -1,0 +1,7 @@
+package com.working.pic.common.controller;
+
+public record ShutdownResponse(
+	String requestTime,
+	String completedTime
+) {
+}

--- a/src/main/resources/templates/success-shutdown.html
+++ b/src/main/resources/templates/success-shutdown.html
@@ -10,6 +10,7 @@
 <div class="success-container">
     <h2>Graceful Shutdown 테스트 완료</h2>
     <p>지연 시간: <span th:text="${delay}"></span>초</p>
+    <p>요청 시간: <span th:text="${requestTime}"></span></p>
 </div>
 </body>
 </html>

--- a/src/main/resources/templates/success-shutdown.html
+++ b/src/main/resources/templates/success-shutdown.html
@@ -9,8 +9,8 @@
 <body>
 <div class="success-container">
     <h2>Graceful Shutdown 테스트 완료</h2>
-    <p>지연 시간: <span th:text="${delay}"></span>초</p>
     <p>요청 시간: <span th:text="${requestTime}"></span></p>
+    <p>완료 시간: <span th:text="${completeTime}"></span></p>
 </div>
 </body>
 </html>


### PR DESCRIPTION
### PR의 목적이 무엇인가요?
테스트에서 로깅을 편리하게 할 목적으로, JSON 응답을 반환하는 기존과 동일한 API 추가

### 이슈 ID는 무엇인가요?
#22 

### 내용
- [x] /terminate 호출 후 재활성화를 위해 사용하는 /activate API 추가
- [x] WebClient 사용 테스트를 위한 Spring Webflux 의존성 추가
- [x] JSON 반환 API 추가 